### PR TITLE
Fix docs for `printFileSizesAfterBuild` (#2942)

### DIFF
--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -170,9 +170,9 @@ module: {
 
 Captures JS and CSS asset sizes inside the passed `buildFolder`. Save the result value to compare it after the build.
 
-##### `printFileSizesAfterBuild(webpackStats: WebpackStats, previousFileSizes: OpaqueFileSizes)`
+##### `printFileSizesAfterBuild(webpackStats: WebpackStats, previousFileSizes: OpaqueFileSizes, buildFolder: string, maxBundleGzipSize?: number, maxChunkGzipSize?: number)`
 
-Prints the JS and CSS asset sizes after the build, and includes a size comparison with `previousFileSizes` that were captured earlier using `measureFileSizesBeforeBuild()`.
+Prints the JS and CSS asset sizes after the build, and includes a size comparison with `previousFileSizes` that were captured earlier using `measureFileSizesBeforeBuild()`. `maxBundleGzipSize` and `maxChunkGzipSizemay` may optionally be specified to display a warning when the main bundle or a chunk exceeds the specified size (in bytes).
 
 ```js
 var {
@@ -182,7 +182,7 @@ var {
 
 measureFileSizesBeforeBuild(buildFolder).then(previousFileSizes => {
   return cleanAndRebuild().then(webpackStats => {
-    printFileSizesAfterBuild(webpackStats, previousFileSizes);
+    printFileSizesAfterBuild(webpackStats, previousFileSizes, buildFolder);
   });
 });
 ```


### PR DESCRIPTION
* Fix docs for `printFileSizesAfterBuild`

* Add optionals parameters for `printFileSizesAfterBuild`

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
